### PR TITLE
critical fix which ensure STDIN is set for command which require input

### DIFF
--- a/src/Commands/Eve/UpdateSde.php
+++ b/src/Commands/Eve/UpdateSde.php
@@ -81,9 +81,12 @@ class UpdateSde extends Command
      */
     public function __construct()
     {
-
         parent::__construct();
 
+        // Ensure STDIN is set (could be not on some setup)
+        if (!defined('STDIN')) {
+            define('STDIN',fopen("php://stdin","r"));
+        }
     }
 
     /**

--- a/src/Commands/Seat/Admin/Email.php
+++ b/src/Commands/Seat/Admin/Email.php
@@ -50,9 +50,12 @@ class Email extends Command
      */
     public function __construct()
     {
-
         parent::__construct();
 
+        // Ensure STDIN is set (could be not on some setup)
+        if (!defined('STDIN')) {
+            define('STDIN',fopen("php://stdin","r"));
+        }
     }
 
     /**

--- a/src/Commands/Seat/Admin/Reset.php
+++ b/src/Commands/Seat/Admin/Reset.php
@@ -54,9 +54,12 @@ class Reset extends Command
      */
     public function __construct()
     {
-
         parent::__construct();
 
+        // Ensure STDIN is set (could be not on some setup)
+        if (!defined('STDIN')) {
+            define('STDIN',fopen("php://stdin","r"));
+        }
     }
 
     /**

--- a/src/Commands/Seat/Cache/Clear.php
+++ b/src/Commands/Seat/Cache/Clear.php
@@ -57,8 +57,12 @@ class Clear extends Command
      */
     public function __construct()
     {
-
         parent::__construct();
+
+        // Ensure STDIN is set (could be not on some setup)
+        if (!defined('STDIN')) {
+            define('STDIN',fopen("php://stdin","r"));
+        }
     }
 
     /**


### PR DESCRIPTION
on some setup, STDIN could be not defined while running script from cgi (CPanel ?)

if stdin is not set, command will loop forever without any way for the user to break it except ctrl+c