### PR TITLE
Diagnose command, allow checking of redis via socket connection

### DIFF
--- a/src/Commands/Seat/Admin/Diagnose.php
+++ b/src/Commands/Seat/Admin/Diagnose.php
@@ -217,10 +217,19 @@ class Diagnose extends Command
 
         try {
 
-            $redis = new Client([
-                'host' => config('database.redis.default.host'),
-                'port' => config('database.redis.default.port'),
-            ]);
+            if (config('database.redis.default.path') != null && config('database.redis.default.scheme') != null) {
+                $redis = new Client([
+                    'scheme' => config('database.redis.default.scheme'),
+                    'path'   => config('database.redis.default.path'),
+                ]);
+            }
+            else {
+                $redis = new Client([
+                    'host' => config('database.redis.default.host'),
+                    'port' => config('database.redis.default.port'),
+                ]);
+            }
+
             $this->info('Connected to Redis');
 
             $redis->set($test_key, Carbon::now());


### PR DESCRIPTION
This updates the seat:admin:diagnose command to not error when a non-tcp redis connection is used and a socket is specified instead.

By default this check would be skipped unless you modify your .env file and the database config to add `scheme` and `path` keys.