### PR TITLE
fix(jobs): use proper job into assets pipe in order to collect assets Locations

### DIFF
--- a/src/Bus/CharacterTokenShouldUpdate.php
+++ b/src/Bus/CharacterTokenShouldUpdate.php
@@ -23,6 +23,7 @@
 namespace Seat\Console\Bus;
 
 use Seat\Eveapi\Jobs\Assets\Character\Assets;
+use Seat\Eveapi\Jobs\Assets\Character\Locations;
 use Seat\Eveapi\Jobs\Assets\Character\Names;
 use Seat\Eveapi\Jobs\Bookmarks\Character\Bookmarks;
 use Seat\Eveapi\Jobs\Bookmarks\Character\Folders;
@@ -110,7 +111,7 @@ class CharacterTokenShouldUpdate extends BusCommand
 
         // Assets
         Assets::withChain([
-            new Location($this->token), new Names($this->token),
+            new Locations($this->token), new Names($this->token),
         ])->dispatch($this->token)->onQueue($this->queue);
 
         // Bookmarks


### PR DESCRIPTION
Since the bus apparition, we're using Character Location job in the pool of Assets jobs instead of the Asset Location.

Thanks to @wfjsw who spot the issue