### PR TITLE
refactor(core): move AbstractSeatPlugin from services to seat package

### DIFF
--- a/src/ConsoleServiceProvider.php
+++ b/src/ConsoleServiceProvider.php
@@ -22,6 +22,7 @@
 
 namespace Seat\Console;
 
+use App\Providers\AbstractSeatPlugin;
 use Seat\Console\Commands\Esi\Dispatch;
 use Seat\Console\Commands\Esi\Ping;
 use Seat\Console\Commands\Esi\Update\Characters as CharactersUpdater;
@@ -38,7 +39,6 @@ use Seat\Console\Commands\Seat\Admin\Maintenance;
 use Seat\Console\Commands\Seat\Cache\Clear;
 use Seat\Console\Commands\Seat\Queue\Status;
 use Seat\Console\Commands\Seat\Version;
-use Seat\Services\AbstractSeatPlugin;
 
 class ConsoleServiceProvider extends AbstractSeatPlugin
 {


### PR DESCRIPTION
in order to keep consistency with packages, AbstractSeatPlugin is
moved to main package - as it will be extended by every single seat
packages (core and third party).