### PR TITLE
feat: publish esi configuration outside package

### DIFF
--- a/src/Commands/Seat/Admin/Diagnose.php
+++ b/src/Commands/Seat/Admin/Diagnose.php
@@ -154,15 +154,15 @@ class Diagnose extends Command
         else
             $this->info(storage_path() . ' is writable');
 
-        if (! File::isWritable(config('eveapi.config.eseye_logfile')))
-            $this->error(config('eveapi.config.eseye_logfile') . ' is not writable');
+        if (! File::isWritable(config('esi.eseye_logfile')))
+            $this->error(config('esi.eseye_logfile') . ' is not writable');
         else
-            $this->info(config('eveapi.config.eseye_logfile') . ' is writable');
+            $this->info(config('esi.eseye_logfile') . ' is writable');
 
-        if (! File::isWritable(config('eveapi.config.eseye_cache')))
-            $this->error(config('eveapi.config.eseye_cache') . ' is not writable');
+        if (! File::isWritable(config('esi.eseye_cache')))
+            $this->error(config('esi.eseye_cache') . ' is not writable');
         else
-            $this->info(config('eveapi.config.eseye_cache') . ' is writable');
+            $this->info(config('esi.eseye_cache') . ' is writable');
 
         if (! File::isWritable(storage_path() . '/sde/'))
             $this->error(storage_path() . '/sde/' . ' is not writable');


### PR DESCRIPTION
Configuration related to ESI will now be available inside `SEAT_PATH/config/esi.php` and a new tag will be available (`seat`) - allowing to publish certain part of the project.

This will avoid to use `php artisan vendor:publish --all` :)

Special thanks to @wfjsw which point me to that workflow.