### PR TITLE
Enforce bus usage with ESI entity commands

### DIFF
--- a/src/Bus/CharacterBus.php
+++ b/src/Bus/CharacterBus.php
@@ -25,8 +25,6 @@ namespace Seat\Console\Bus;
 use Seat\Eveapi\Jobs\Assets\Character\Assets;
 use Seat\Eveapi\Jobs\Assets\Character\Locations;
 use Seat\Eveapi\Jobs\Assets\Character\Names;
-use Seat\Eveapi\Jobs\Bookmarks\Character\Bookmarks;
-use Seat\Eveapi\Jobs\Bookmarks\Character\Folders;
 use Seat\Eveapi\Jobs\Calendar\Attendees;
 use Seat\Eveapi\Jobs\Calendar\Detail;
 use Seat\Eveapi\Jobs\Calendar\Events;
@@ -66,10 +64,10 @@ use Seat\Eveapi\Jobs\Wallet\Character\Transactions;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
- * Class CharacterShouldUpdate.
+ * Class CharacterBus.
  * @package Seat\Console\Bus
  */
-class CharacterTokenShouldUpdate extends BusCommand
+class CharacterBus extends BusCommand
 {
     /**
      * @var \Seat\Eveapi\Models\RefreshToken
@@ -114,21 +112,21 @@ class CharacterTokenShouldUpdate extends BusCommand
                 new Skills($this->token),
             ]),
 
-            // collect military information
+            // collect military informations
             new Fittings($this->token),
             new Recent($this->token),
 
             new Fatigue($this->token),
             new Medals($this->token),
 
-            // collect industrial information
+            // collect industrial informations
             (new Blueprints($this->token))->chain([
                 new Jobs($this->token),
                 new Mining($this->token),
                 new AgentsResearch($this->token),
             ]),
 
-            // collect financial information
+            // collect financial informations
             new Orders($this->token),
             new Contracts($this->token),
             new Planets($this->token),
@@ -137,7 +135,7 @@ class CharacterTokenShouldUpdate extends BusCommand
                 new Transactions($this->token),
             ]),
 
-            // collect intel information
+            // collect intel informations
             new Standings($this->token),
             (new Contacts($this->token))->chain([
                 new ContactLabels($this->token),
@@ -148,19 +146,18 @@ class CharacterTokenShouldUpdate extends BusCommand
                 new MailingLists($this->token),
             ]),
 
-            // Calendar Events
+            // calendar events
             (new Events($this->token))->chain([
                 new Detail($this->token),
                 new Attendees($this->token),
             ]),
 
-            // Assets
+            // assets
             (new Assets($this->token))->chain([
-                new Locations($this->token),
                 new Names($this->token),
+                new Locations($this->token),
+                new CharacterStructures($this->token),
             ]),
-
-            new CharacterStructures($this->token),
         ])->dispatch($this->token->character_id);
     }
 }

--- a/src/Bus/CharacterTokenShouldUpdate.php
+++ b/src/Bus/CharacterTokenShouldUpdate.php
@@ -94,84 +94,73 @@ class CharacterTokenShouldUpdate extends BusCommand
      */
     public function fire()
     {
-
-        // Assets
-        Assets::withChain([
-            new Locations($this->token), new Names($this->token),
-        ])->dispatch($this->token);
-
-        // Bookmarks
-        Bookmarks::withChain([
-            new Folders($this->token),
-        ])->dispatch($this->token);
-
-        // Calendar
-        Events::withChain([
-            new Detail($this->token), new Attendees($this->token),
-        ])->dispatch($this->token);
-
         // Character
-        Info::dispatch($this->token->character_id);
-        AgentsResearch::dispatch($this->token);
-        Blueprints::dispatch($this->token);
-        CorporationHistory::dispatch($this->token->character_id);
-        Fatigue::dispatch($this->token);
-        Medals::dispatch($this->token);
-        Roles::dispatch($this->token);
-        Standings::dispatch($this->token);
-        Titles::dispatch($this->token);
+        Info::withChain([
+            // collect information related to current character state
+            new CorporationHistory($this->token->character_id),
+            new Roles($this->token),
+            new Titles($this->token),
+            (new Clones($this->token))->chain([
+                new Implants($this->token),
+            ]),
 
-        // Clones
-        Clones::withChain([
-            new Implants($this->token),
-        ])->dispatch($this->token);
+            (new Location($this->token))->chain([
+                new Online($this->token),
+                new Ship($this->token),
+            ]),
 
-        // Contacts
-        Contacts::withChain([
-            new ContactLabels($this->token),
-        ])->dispatch($this->token);
+            (new Attributes($this->token))->chain([
+                new Queue($this->token),
+                new Skills($this->token),
+            ]),
 
-        // Contracts
-        Contracts::dispatch($this->token);
+            // collect military information
+            new Fittings($this->token),
+            new Recent($this->token),
 
-        // Fittings
-        Fittings::dispatch($this->token);
+            new Fatigue($this->token),
+            new Medals($this->token),
 
-        // Industry
-        Jobs::dispatch($this->token);
-        Mining::dispatch($this->token);
+            // collect industrial information
+            (new Blueprints($this->token))->chain([
+                new Jobs($this->token),
+                new Mining($this->token),
+                new AgentsResearch($this->token),
+            ]),
 
-        // Killmails
-        Recent::dispatch($this->token);
+            // collect financial information
+            new Orders($this->token),
+            new Contracts($this->token),
+            new Planets($this->token),
+            (new Balance($this->token))->chain([
+                new Journal($this->token),
+                new Transactions($this->token),
+            ]),
 
-        // Location
-        Location::dispatch($this->token);
-        Online::dispatch($this->token);
-        Ship::dispatch($this->token);
+            // collect intel information
+            new Standings($this->token),
+            (new Contacts($this->token))->chain([
+                new ContactLabels($this->token),
+            ]),
 
-        // Mail
-        Mails::withChain([
-            new MailLabels($this->token),
-        ])->dispatch($this->token);
-        MailingLists::dispatch($this->token);
+            (new Mails($this->token))->chain([
+                new MailLabels($this->token),
+                new MailingLists($this->token),
+            ]),
 
-        // Market
-        Orders::dispatch($this->token);
+            // Calendar Events
+            (new Events($this->token))->chain([
+                new Detail($this->token),
+                new Attendees($this->token),
+            ]),
 
-        // Planetary Interactions
-        Planets::dispatch($this->token);
+            // Assets
+            (new Assets($this->token))->chain([
+                new Locations($this->token),
+                new Names($this->token),
+            ]),
 
-        // Skills
-        Attributes::dispatch($this->token);
-        Queue::dispatch($this->token);
-        Skills::dispatch($this->token);
-
-        // Structures
-        CharacterStructures::dispatch($this->token);
-
-        // Wallet
-        Balance::dispatch($this->token);
-        Journal::dispatch($this->token);
-        Transactions::dispatch($this->token);
+            new CharacterStructures($this->token),
+        ])->dispatch($this->token->character_id);
     }
 }

--- a/src/Bus/CorporationBus.php
+++ b/src/Bus/CorporationBus.php
@@ -111,13 +111,13 @@ class CorporationBus extends BusCommand
                 new MembersTitles($this->corporation_id, $this->token),
             ]),
 
-            (new Medals($this->corporation_id, $this->token))->chain([
-                new IssuedMedals($this->corporation_id, $this->token),
-            ]),
-
             (new MembersLimit($this->corporation_id, $this->token))->chain([
                 new Members($this->corporation_id, $this->token),
                 new MemberTracking($this->corporation_id, $this->token),
+            ]),
+
+            (new Medals($this->corporation_id, $this->token))->chain([
+                new IssuedMedals($this->corporation_id, $this->token),
             ]),
 
             // collect military informations

--- a/src/Bus/CorporationBus.php
+++ b/src/Bus/CorporationBus.php
@@ -25,8 +25,6 @@ namespace Seat\Console\Bus;
 use Seat\Eveapi\Jobs\Assets\Corporation\Assets;
 use Seat\Eveapi\Jobs\Assets\Corporation\Locations;
 use Seat\Eveapi\Jobs\Assets\Corporation\Names;
-use Seat\Eveapi\Jobs\Bookmarks\Corporation\Bookmarks;
-use Seat\Eveapi\Jobs\Bookmarks\Corporation\Folders;
 use Seat\Eveapi\Jobs\Contacts\Corporation\Contacts;
 use Seat\Eveapi\Jobs\Contacts\Corporation\Labels;
 use Seat\Eveapi\Jobs\Contracts\Corporation\Contracts;
@@ -65,10 +63,10 @@ use Seat\Eveapi\Jobs\Wallet\Corporation\Transactions;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
- * Class CorporationCharacterShouldUpdate.
+ * Class CorporationBus.
  * @package Seat\Console\Bus
  */
-class CorporationTokenShouldUpdate extends BusCommand
+class CorporationBus extends BusCommand
 {
     /**
      * @var int
@@ -101,67 +99,72 @@ class CorporationTokenShouldUpdate extends BusCommand
     public function fire()
     {
 
-        Assets::withChain([
-            new Locations($this->corporation_id, $this->token), new Names($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
+        Info::withChain([
+            new AllianceHistory($this->corporation_id),
+            new Divisions($this->corporation_id, $this->token),
 
-        Bookmarks::withChain([
-            new Folders($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
+            (new Roles($this->corporation_id, $this->token))->chain([
+                new RoleHistories($this->corporation_id, $this->token),
+            ]),
 
-        Contacts::withChain([
-            new Labels($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
+            (new Titles($this->corporation_id, $this->token))->chain([
+                new MembersTitles($this->corporation_id, $this->token),
+            ]),
 
-        Contracts::dispatch($this->corporation_id, $this->token);
+            (new Medals($this->corporation_id, $this->token))->chain([
+                new IssuedMedals($this->corporation_id, $this->token),
+            ]),
 
-        Info::dispatch($this->corporation_id);
-        AllianceHistory::dispatch($this->corporation_id);
-        Blueprints::dispatch($this->corporation_id, $this->token);
-        ContainerLogs::dispatch($this->corporation_id, $this->token);
-        Divisions::dispatch($this->corporation_id, $this->token);
-        Facilities::dispatch($this->corporation_id, $this->token);
-        IssuedMedals::dispatch($this->corporation_id, $this->token);
-        Medals::dispatch($this->corporation_id, $this->token);
-        Members::dispatch($this->corporation_id, $this->token);
-        MembersLimit::dispatch($this->corporation_id, $this->token);
-        MemberTracking::dispatch($this->corporation_id, $this->token);
+            (new MembersLimit($this->corporation_id, $this->token))->chain([
+                new Members($this->corporation_id, $this->token),
+                new MemberTracking($this->corporation_id, $this->token),
+            ]),
 
-        Roles::withChain([
-            new RoleHistories($this->corporation_id, $this->token), ]
-        )->dispatch($this->corporation_id, $this->token);
+            // collect military informations
+            new Recent($this->corporation_id, $this->token),
 
-        Shareholders::dispatch($this->corporation_id, $this->token);
-        Standings::dispatch($this->corporation_id, $this->token);
+            // collect industrial informations
+            (new Blueprints($this->corporation_id, $this->token))->chain([
+                new Facilities($this->corporation_id, $this->token),
+                new Jobs($this->corporation_id, $this->token),
+                (new Observers($this->corporation_id, $this->token))->chain([
+                    new ObserverDetails($this->corporation_id, $this->token),
+                ]),
+            ]),
 
-        Starbases::withChain([
-            new StarbaseDetails($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
+            // collect financial informations
+            new Orders($this->corporation_id, $this->token),
+            new Contracts($this->corporation_id, $this->token),
+            new Shareholders($this->corporation_id, $this->token),
+            (new Balances($this->corporation_id, $this->token))->chain([
+                new Journals($this->corporation_id, $this->token),
+                new Transactions($this->corporation_id, $this->token),
+            ]),
 
-        Structures::dispatch($this->corporation_id, $this->token);
-        CorporationStructures::dispatch($this->corporation_id, $this->token);
+            // collect intel informations
+            new Standings($this->corporation_id, $this->token),
+            (new Contacts($this->corporation_id, $this->token))->chain([
+                new Labels($this->corporation_id, $this->token),
+            ]),
 
-        CustomsOffices::withChain([
-            new CustomsOfficeLocations($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
+            // structures
+            (new Starbases($this->corporation_id, $this->token))->chain([
+                new StarbaseDetails($this->corporation_id, $this->token),
+            ]),
+            (new Structures($this->corporation_id, $this->token))->chain([
+                new Extractions($this->corporation_id, $this->token),
+            ]),
+            (new CustomsOffices($this->corporation_id, $this->token))->chain([
+                new CustomsOfficeLocations($this->corporation_id, $this->token),
+            ]),
 
-        Titles::withChain([
-            new MembersTitles($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
-
-        Jobs::dispatch($this->corporation_id, $this->token);
-        Extractions::dispatch($this->corporation_id, $this->token);
-
-        Observers::withChain([
-            new ObserverDetails($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id, $this->token);
-
-        Recent::dispatch($this->corporation_id, $this->token);
-
-        Orders::dispatch($this->corporation_id, $this->token);
-
-        Balances::dispatch($this->corporation_id, $this->token);
-        Journals::dispatch($this->corporation_id, $this->token);
-        Transactions::dispatch($this->corporation_id, $this->token);
+            // assets
+            (new Assets($this->corporation_id, $this->token))->chain([
+                new ContainerLogs($this->corporation_id, $this->token),
+                new Locations($this->corporation_id, $this->token),
+                new Names($this->corporation_id, $this->token),
+                new CorporationStructures($this->corporation_id, $this->token),
+            ]),
+        ])->dispatch($this->corporation_id);
     }
 }

--- a/src/Commands/Esi/Update/Characters.php
+++ b/src/Commands/Esi/Update/Characters.php
@@ -23,7 +23,7 @@
 namespace Seat\Console\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
-use Seat\Console\Bus\CharacterTokenShouldUpdate;
+use Seat\Console\Bus\CharacterBus;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
@@ -61,7 +61,7 @@ class Characters extends Command
             ->each(function ($token) {
 
                 // Fire the class that handles the collection of jobs to run.
-                (new CharacterTokenShouldUpdate($token, 'default'))->fire();
+                (new CharacterBus($token))->fire();
             });
 
         $this->info('Processed ' . $tokens->count() . ' refresh tokens.');

--- a/src/Commands/Esi/Update/Corporations.php
+++ b/src/Commands/Esi/Update/Corporations.php
@@ -23,7 +23,7 @@
 namespace Seat\Console\Commands\Esi\Update;
 
 use Illuminate\Console\Command;
-use Seat\Console\Bus\CorporationTokenShouldUpdate;
+use Seat\Console\Bus\CorporationBus;
 use Seat\Eveapi\Models\RefreshToken;
 
 /**
@@ -63,7 +63,7 @@ class Corporations extends Command
 
                 // Fire the class to update corporation information
                 if ($token->character->affiliation->corporation_id != null)
-                    (new CorporationTokenShouldUpdate($token->character->affiliation->corporation_id, $token))->fire();
+                    (new CorporationBus($token->character->affiliation->corporation_id, $token))->fire();
             });
 
         $this->info('Processed ' . $tokens->count() . ' refresh tokens.');


### PR DESCRIPTION
This is a small refactor which is using a bit more chaining process with either `esi:update:characters` or `esi:update:corporations`.

Assets jobs are pull at the end of each bus since it's the job with which we may experiments more issues due to location resolve attempts.

I also reorder a bit certain jobs, so we gather "critical" data faster (ie: corporation titles, members, etc...).

With the amount of jobs we have, it seems a bit more clean since only parent job will be available in queue and we will process characters/corporations by batch using same token (or avoiding as much as possible token refresh conflict).