### PR TITLE
feat: delay queued jobs using a random window

### DIFF
--- a/src/Bus/Alliance.php
+++ b/src/Bus/Alliance.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of SeAT
+ *
+ * Copyright (C) 2015 to 2020 Leon Jacobs
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+namespace Seat\Console\Bus;
+
+use Seat\Eveapi\Jobs\Alliances\Info;
+use Seat\Eveapi\Jobs\Alliances\Members;
+use Seat\Eveapi\Jobs\Contacts\Alliance\Contacts;
+use Seat\Eveapi\Jobs\Contacts\Alliance\Labels;
+use Seat\Eveapi\Models\RefreshToken;
+
+/**
+ * Class Alliance.
+ *
+ * @package Seat\Console\Bus
+ */
+class Alliance extends BusCommand
+{
+    /**
+     * @var int
+     */
+    private $alliance_id;
+
+    /**
+     * @var \Seat\Eveapi\Models\RefreshToken
+     */
+    private $token;
+
+    /**
+     * Alliance constructor.
+     *
+     * @param int $alliance_id
+     * @param \Seat\Eveapi\Models\RefreshToken $token
+     */
+    public function __construct(int $alliance_id, RefreshToken $token)
+    {
+        $this->token = $token;
+        $this->alliance_id = $alliance_id;
+    }
+
+    public function fire()
+    {
+        Info::withChain([
+            new Members($this->alliance_id),
+            new Labels($this->alliance_id, $this->token),
+            new Contacts($this->alliance_id, $this->token),
+        ])->dispatch($this->alliance_id)->delay(now()->addSeconds(rand(120, 600)));
+        // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
+        // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
+        // https://github.com/eveseat/seat/issues/731
+    }
+}

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -149,7 +149,7 @@ class Character extends BusCommand
             new Names($this->token),
             new Locations($this->token),
             new CharacterStructures($this->token),
-        ])->dispatch($this->token->character_id)->delay(now()->addSeconds(rand(30, 300)));
+        ])->dispatch($this->token->character_id)->delay(now()->addSeconds(rand(10, 120)));
         // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
         // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
         // https://github.com/eveseat/seat/issues/731

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -149,6 +149,9 @@ class Character extends BusCommand
             new Names($this->token),
             new Locations($this->token),
             new CharacterStructures($this->token),
-        ])->dispatch($this->token->character_id);
+        ])->dispatch($this->token->character_id)->delay(now()->addSeconds(rand(30, 300)));
+        // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
+        // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
+        // https://github.com/eveseat/seat/issues/731
     }
 }

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -41,7 +41,6 @@ use Seat\Eveapi\Jobs\Clones\Clones;
 use Seat\Eveapi\Jobs\Clones\Implants;
 use Seat\Eveapi\Jobs\Contacts\Character\Contacts;
 use Seat\Eveapi\Jobs\Contacts\Character\Labels as ContactLabels;
-use Seat\Eveapi\Jobs\Contracts\Character\Contracts;
 use Seat\Eveapi\Jobs\Fittings\Character\Fittings;
 use Seat\Eveapi\Jobs\Industry\Character\Jobs;
 use Seat\Eveapi\Jobs\Industry\Character\Mining;
@@ -122,7 +121,6 @@ class Character extends BusCommand
 
             // collect financial informations
             new Orders($this->token),
-            new Contracts($this->token),
             new Planets($this->token),
             new Balance($this->token),
             new Journal($this->token),

--- a/src/Bus/Character.php
+++ b/src/Bus/Character.php
@@ -45,7 +45,6 @@ use Seat\Eveapi\Jobs\Contracts\Character\Contracts;
 use Seat\Eveapi\Jobs\Fittings\Character\Fittings;
 use Seat\Eveapi\Jobs\Industry\Character\Jobs;
 use Seat\Eveapi\Jobs\Industry\Character\Mining;
-use Seat\Eveapi\Jobs\Killmails\Character\Recent;
 use Seat\Eveapi\Jobs\Location\Character\Location;
 use Seat\Eveapi\Jobs\Location\Character\Online;
 use Seat\Eveapi\Jobs\Location\Character\Ship;
@@ -111,7 +110,6 @@ class Character extends BusCommand
 
             // collect military informations
             new Fittings($this->token),
-            new Recent($this->token),
 
             new Fatigue($this->token),
             new Medals($this->token),

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -52,7 +52,6 @@ use Seat\Eveapi\Jobs\Industry\Corporation\Jobs;
 use Seat\Eveapi\Jobs\Industry\Corporation\Mining\Extractions;
 use Seat\Eveapi\Jobs\Industry\Corporation\Mining\ObserverDetails;
 use Seat\Eveapi\Jobs\Industry\Corporation\Mining\Observers;
-use Seat\Eveapi\Jobs\Killmails\Corporation\Recent;
 use Seat\Eveapi\Jobs\Market\Corporation\Orders;
 use Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation\CustomsOfficeLocations;
 use Seat\Eveapi\Jobs\PlanetaryInteraction\Corporation\CustomsOffices;
@@ -115,9 +114,6 @@ class Corporation extends BusCommand
 
             new Medals($this->corporation_id, $this->token),
             new IssuedMedals($this->corporation_id, $this->token),
-
-            // collect military informations
-            new Recent($this->corporation_id, $this->token),
 
             // collect industrial informations
             new Blueprints($this->corporation_id, $this->token),

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -153,7 +153,7 @@ class Corporation extends BusCommand
             new Locations($this->corporation_id, $this->token),
             new Names($this->corporation_id, $this->token),
             new CorporationStructures($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id)->delay(now()->addSeconds(rand(120, 600)));
+        ])->dispatch($this->corporation_id)->delay(now()->addSeconds(rand(120, 300)));
         // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
         // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
         // https://github.com/eveseat/seat/issues/731

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -153,6 +153,9 @@ class Corporation extends BusCommand
             new Locations($this->corporation_id, $this->token),
             new Names($this->corporation_id, $this->token),
             new CorporationStructures($this->corporation_id, $this->token),
-        ])->dispatch($this->corporation_id);
+        ])->dispatch($this->corporation_id)->delay(now()->addSeconds(rand(120, 600)));
+        // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
+        // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
+        // https://github.com/eveseat/seat/issues/731
     }
 }

--- a/src/Bus/Corporation.php
+++ b/src/Bus/Corporation.php
@@ -27,7 +27,6 @@ use Seat\Eveapi\Jobs\Assets\Corporation\Locations;
 use Seat\Eveapi\Jobs\Assets\Corporation\Names;
 use Seat\Eveapi\Jobs\Contacts\Corporation\Contacts;
 use Seat\Eveapi\Jobs\Contacts\Corporation\Labels;
-use Seat\Eveapi\Jobs\Contracts\Corporation\Contracts;
 use Seat\Eveapi\Jobs\Corporation\AllianceHistory;
 use Seat\Eveapi\Jobs\Corporation\Blueprints;
 use Seat\Eveapi\Jobs\Corporation\ContainerLogs;
@@ -124,7 +123,6 @@ class Corporation extends BusCommand
 
             // collect financial informations
             new Orders($this->corporation_id, $this->token),
-            new Contracts($this->corporation_id, $this->token),
             new Shareholders($this->corporation_id, $this->token),
             new Balances($this->corporation_id, $this->token),
             new Journals($this->corporation_id, $this->token),

--- a/src/Commands/Esi/Update/Alliances.php
+++ b/src/Commands/Esi/Update/Alliances.php
@@ -27,8 +27,6 @@ use Seat\Console\Bus\Alliance as AllianceBus;
 use Seat\Eveapi\Jobs\Alliances\Alliances as AlliancesJob;
 use Seat\Eveapi\Jobs\Alliances\Info;
 use Seat\Eveapi\Jobs\Alliances\Members;
-use Seat\Eveapi\Jobs\Contacts\Alliance\Contacts;
-use Seat\Eveapi\Jobs\Contacts\Alliance\Labels;
 use Seat\Eveapi\Models\Alliances\Alliance;
 use Seat\Eveapi\Models\RefreshToken;
 

--- a/src/Commands/Esi/Update/Alliances.php
+++ b/src/Commands/Esi/Update/Alliances.php
@@ -101,7 +101,7 @@ class Alliances extends Command
 
             Info::withChain([
                 new Members($alliance->alliance_id),
-            ])->dispatch($alliance->alliance_id)->delay(now()->addSeconds(rand(20, 600)));
+            ])->dispatch($alliance->alliance_id)->delay(now()->addSeconds(rand(20, 300)));
         })->isEmpty() && empty($alliance_ids)) AlliancesJob::dispatch();
     }
 }

--- a/src/Commands/Esi/Update/Corporations.php
+++ b/src/Commands/Esi/Update/Corporations.php
@@ -59,6 +59,7 @@ class Corporations extends Command
         $tokens = RefreshToken::whereHas('character.affiliation', function ($query) {
             $query->whereNotNull('corporation_id');
         })->whereHas('character.corporation_roles', function ($query) {
+            $query->where('scope', 'roles');
             $query->where('role', 'Director');
         })->when($this->argument('character_id'), function ($tokens) {
             return $tokens->where('character_id', $this->argument('character_id'));

--- a/src/Commands/Esi/Update/Corporations.php
+++ b/src/Commands/Esi/Update/Corporations.php
@@ -39,7 +39,7 @@ class Corporations extends Command
      * @var string
      */
     protected $signature = 'esi:update:corporations {character_id? : Optional character_id to update ' .
-    'corporation information for}';
+        'corporation information for}';
 
     /**
      * The console command description.
@@ -53,18 +53,19 @@ class Corporations extends Command
      */
     public function handle()
     {
+        // to prevent excessive calls, we queue only jobs for tokens with Director role.
+        // more than 80% of corporation endpoints are requiring this role anyway.
+        // https://github.com/eveseat/seat/issues/731
+        RefreshToken::whereHas('character.corporation_roles', function ($query) {
+            $query->where('role', 'Director');
+        })->when($this->argument('character_id'), function ($tokens) {
+            return $tokens->where('character_id', $this->argument('character_id'));
+        })->each(function ($tokens) {
 
-        $tokens = RefreshToken::all()
-            ->when($this->argument('character_id'), function ($tokens) {
-
-                return $tokens->where('character_id', $this->argument('character_id'));
-            })
-            ->each(function ($token) {
-
-                // Fire the class to update corporation information
-                if ($token->character->affiliation->corporation_id != null)
-                    (new Corporation($token->character->affiliation->corporation_id, $token))->fire();
-            });
+            // Fire the class to update corporation information
+            if ($token->character->affiliation->corporation_id != null)
+                (new Corporation($token->character->affiliation->corporation_id, $token))->fire();
+        });
 
         $this->info('Processed ' . $tokens->count() . ' refresh tokens.');
 

--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -92,7 +92,7 @@ class PublicInfo extends Command
         CharacterInfo::doesntHave('refresh_token')->each(function ($character) {
             CharacterInfoJob::withChain([
                 new CorporationHistory($character->character_id),
-            ])->dispatch($character->character_id)->delay(rand(30, 300));
+            ])->dispatch($character->character_id)->delay(rand(10, 120));
             // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
             // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
             // https://github.com/eveseat/seat/issues/731
@@ -101,7 +101,7 @@ class PublicInfo extends Command
         CorporationInfo::all()->each(function ($corporation) {
             CorporationInfoJob::withChain([
                 new AllianceHistory($corporation->corporation_id),
-            ])->dispatch($corporation->corporation_id)->delay(rand(120, 600));
+            ])->dispatch($corporation->corporation_id)->delay(rand(120, 300));
             // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
             // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
             // https://github.com/eveseat/seat/issues/731

--- a/src/Commands/Esi/Update/PublicInfo.php
+++ b/src/Commands/Esi/Update/PublicInfo.php
@@ -64,7 +64,7 @@ class PublicInfo extends Command
      */
     public function handle()
     {
-        // NPC stations
+        // NPC stations using HQ
         CorporationInfo::whereNotIn('home_station_id', UniverseStation::FAKE_STATION_ID)
             ->select('home_station_id')
             ->orderBy('home_station_id')
@@ -73,7 +73,7 @@ class PublicInfo extends Command
                 Stations::dispatch($corporations->pluck('home_station_id')->toArray());
             });
 
-        // corporation assets
+        // NPC stations using corporation assets
         CorporationAsset::where('location_type', 'station')
             ->select('location_id')
             ->orderBy('location_id')
@@ -90,13 +90,21 @@ class PublicInfo extends Command
         Insurances::dispatch();
 
         CharacterInfo::doesntHave('refresh_token')->each(function ($character) {
-            CharacterInfoJob::dispatch($character->character_id);
-            CorporationHistory::dispatch($character->character_id);
+            CharacterInfoJob::withChain([
+                new CorporationHistory($character->character_id),
+            ])->dispatch($character->character_id)->delay(rand(30, 300));
+            // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
+            // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
+            // https://github.com/eveseat/seat/issues/731
         });
 
         CorporationInfo::all()->each(function ($corporation) {
-            CorporationInfoJob::dispatch($corporation->corporation_id);
-            AllianceHistory::dispatch($corporation->corporation_id);
+            CorporationInfoJob::withChain([
+                new AllianceHistory($corporation->corporation_id),
+            ])->dispatch($corporation->corporation_id)->delay(rand(120, 600));
+            // in order to prevent ESI to receive massive income of all existing SeAT instances in the world
+            // add a bit of randomize when job can be processed - we use seconds here, so we have more flexibility
+            // https://github.com/eveseat/seat/issues/731
         });
     }
 }

--- a/src/database/seeds/ScheduleSeeder.php
+++ b/src/database/seeds/ScheduleSeeder.php
@@ -186,16 +186,16 @@ class ScheduleSeeder extends Seeder
 
         foreach ($this->schedules as $key => $schedule) {
             switch ($schedule['command']) {
-                // use random minute, from 12am up to 10am and from 1pm up to 11pm
+                // use random minute - every hour
                 case 'esi:update:characters':
                     $this->schedules[$key]['expression'] = sprintf('%d * * * *', rand(0, 59));
                     break;
-                // use random minute, from 12am up to 10am and from 1pm up to 11pm - every 2 hours
+                // use random minute - every 2 hours
                 case 'esi:update:affiliations':
                 case 'esi:update:corporations':
                     $this->schedules[$key]['expression'] = sprintf('%d */2 * * *', rand(0, 59));
                     break;
-                // use random minute and hour, once a day, between 12am up to 10am and from 1pm up to 11pm
+                // use random minute and hour, once a day
                 case 'esi:update:public':
                 case 'esi:update:prices':
                 case 'esi:update:alliances':

--- a/src/database/seeds/ScheduleSeeder.php
+++ b/src/database/seeds/ScheduleSeeder.php
@@ -39,7 +39,7 @@ class ScheduleSeeder extends Seeder
 
         [   // ESI Status | Every Minute
             'command'           => 'esi:update:status',
-            'expression'        => '* 0-10,13-23 * * *',
+            'expression'        => '* * * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -55,7 +55,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // EVE Server Status | Every Minute
             'command'           => 'eve:update:status',
-            'expression'        => '* 0-10,13-23 * * *',
+            'expression'        => '* * * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -79,7 +79,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // Characters | Hourly
             'command'           => 'esi:update:characters',
-            'expression'        => '0 0-10,13-23 * * *',
+            'expression'        => '0 * * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -87,7 +87,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // Character Affiliation | Every two hours
             'command'           => 'esi:update:affiliations',
-            'expression'        => '0 0-10/2,13-23/2 * * *',
+            'expression'        => '0 */2 * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -95,7 +95,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // Character Notifications | Every twenty minutes
             'command'           => 'esi:update:notifications',
-            'expression'        => '*/20 0-10,13-23 * * *',
+            'expression'        => '*/20 * * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -103,7 +103,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // Corporations | Every two hours
             'command'           => 'esi:update:corporations',
-            'expression'        => '0 0-10/2,13-23/2 * * *',
+            'expression'        => '0 */2 * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -111,7 +111,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // Killmails | Every fifteen minutes
             'command'           => 'esi:update:killmails',
-            'expression'        => '*/15 0-10,13-23 * * *',
+            'expression'        => '*/15 * * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -119,7 +119,7 @@ class ScheduleSeeder extends Seeder
         ],
         [   // Contracts | Every fifteen minutes
             'command'           => 'esi:update:contracts',
-            'expression'        => '*/15 0-10,13-23 * * *',
+            'expression'        => '*/15 * * * *',
             'allow_overlap'     => false,
             'allow_maintenance' => false,
             'ping_before'       => null,
@@ -188,12 +188,12 @@ class ScheduleSeeder extends Seeder
             switch ($schedule['command']) {
                 // use random minute, from 12am up to 10am and from 1pm up to 11pm
                 case 'esi:update:characters':
-                    $this->schedules[$key]['expression'] = sprintf('%d 0-10,13-23 * * *', rand(0, 59));
+                    $this->schedules[$key]['expression'] = sprintf('%d * * * *', rand(0, 59));
                     break;
                 // use random minute, from 12am up to 10am and from 1pm up to 11pm - every 2 hours
                 case 'esi:update:affiliations':
                 case 'esi:update:corporations':
-                    $this->schedules[$key]['expression'] = sprintf('%d 0-10/2,13-23/2 * * *', rand(0, 59));
+                    $this->schedules[$key]['expression'] = sprintf('%d */2 * * *', rand(0, 59));
                     break;
                 // use random minute and hour, once a day, between 12am up to 10am and from 1pm up to 11pm
                 case 'esi:update:public':


### PR DESCRIPTION
to prevent excessive call at time from all existing SeAT instances in the world, add some randomness to token update batches.

also queue jobs related to corporation only for token having a Director role.
most of corporation endpoints are requiring that role and that should reduce the amount of calls by the meantime.

seed scheduler using random values overriding default scheduler at every time it's ran.
to ensure all existing instance benefits of the change, we force scheduler to be seeded even if commands already exist.

EVE Online maintenance window is excluded from schedule - still need to find a way to handle timezone though :(

![image](https://user-images.githubusercontent.com/648753/102661929-12add900-417e-11eb-82b2-39e2fe1ee037.png)
![image](https://user-images.githubusercontent.com/648753/102662027-4557d180-417e-11eb-820e-cf64e17502f1.png)

Closes eveseat/seat#731