### PR TITLE
fix(prices): reduce chunk size to process job in 15min

### DIFF
--- a/src/Commands/Esi/Update/Prices.php
+++ b/src/Commands/Esi/Update/Prices.php
@@ -60,9 +60,9 @@ class Prices extends Command
             ->get();
 
         // build small batch of a maximum of 200 entries to avoid long running job.
-        $types->chunk(200)->each(function ($chunk) {
+        $types->chunk(50)->each(function ($chunk) {
             $ids = $chunk->pluck('typeID')->toArray();
-            History::dispatch($ids);
+            History::dispatch($ids)->delay(rand(20, 300));
         });
     }
 }


### PR DESCRIPTION
current chunk size is preventing job to reach end of list processing before being considered as zombie by the overall job config.

rather than increasing the zombie threshold, we reduce the job duration by asking him to process 75% less types a time.

to reduce pressure against ESI, we also add random delay on each queued job. Since stats are cached for 24 hours long, we can reasonable apply a random window between 20 seconds and 5 minutes.